### PR TITLE
Highlight code within Inner line doc comments

### DIFF
--- a/after/syntax/rust.vim
+++ b/after/syntax/rust.vim
@@ -393,6 +393,7 @@ syntax region rsDocTest
 " This is used to ‘match away’ the ‘///’ at the start of each line in a
 " doctest. It is only allowed to exist within doctests.
 syntax match rsDocCommentHeader '///' containedin=rsDocTest contained
+syntax match rsDocCommentHeader '//!' containedin=rsDocTest contained
 
 highlight default link rsBlockComment rsComment
 highlight default link rsDocCommentHeader rsDocComment


### PR DESCRIPTION
Allows for highlighting of inner line doc comments (module  comments //!).

This is in addition to pr #7.